### PR TITLE
ref: updated github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for <a href="https://github.com/danielyxie/bitburner">Bitburner</a>
+	Catppuccin for <a href="https://github.com/bitburner-official/bitburner-src">Bitburner</a>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 


### PR DESCRIPTION
Hi,

I just updated the URL of bitburner's repo since it was moved.

Old repo: https://github.com/danielyxie/bitburner
New one: https://github.com/bitburner-official/bitburner-src

Thanks in advance.